### PR TITLE
允许不使用apt直接通过实现监听器来回调下载进度更新

### DIFF
--- a/Aria/src/main/java/com/arialyy/aria/core/common/ProxyHelper.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/common/ProxyHelper.java
@@ -117,26 +117,26 @@ public class ProxyHelper {
   }
 
   private Set<Integer> checkProxyTypeByInterface(Class clazz) {
-    if (clazz.isAssignableFrom(BaseListenerInterface.class)) {
+    if (!BaseListenerInterface.class.isAssignableFrom(clazz)) {
       return null;
     }
     Set<Integer> result = new HashSet<>();
-    if (clazz.isAssignableFrom(DownloadGroupTaskListener.class)) {
+    if (DownloadGroupTaskListener.class.isAssignableFrom(clazz)) {
       result.add(PROXY_TYPE_DOWNLOAD_GROUP);
     }
-    if (clazz.isAssignableFrom(DownloadTaskListener.class)) {
+    if (DownloadTaskListener.class.isAssignableFrom(clazz)) {
       result.add(PROXY_TYPE_DOWNLOAD);
     }
 
-    if (clazz.isAssignableFrom(UploadTaskListener.class)) {
+    if (UploadTaskListener.class.isAssignableFrom(clazz)) {
       result.add(PROXY_TYPE_UPLOAD);
     }
 
-    if (clazz.isAssignableFrom(M3U8PeerTaskListenerInterface.class)) {
+    if (M3U8PeerTaskListenerInterface.class.isAssignableFrom(clazz)) {
       result.add(PROXY_TYPE_M3U8_PEER);
     }
 
-    if (clazz.isAssignableFrom(SubTaskListenerInterface.class)) {
+    if (SubTaskListenerInterface.class.isAssignableFrom(clazz)) {
       result.add(PROXY_TYPE_DOWNLOAD_GROUP_SUB);
     }
     return result;

--- a/Aria/src/main/java/com/arialyy/aria/core/common/ProxyHelper.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/common/ProxyHelper.java
@@ -18,7 +18,7 @@ package com.arialyy.aria.core.common;
 import com.arialyy.annotations.TaskEnum;
 import com.arialyy.aria.core.download.DownloadGroupTaskListener;
 import com.arialyy.aria.core.download.DownloadTaskListener;
-import com.arialyy.aria.core.scheduler.BaseListenerInterface;
+import com.arialyy.aria.core.scheduler.DownloadTaskInternalListenerInterface;
 import com.arialyy.aria.core.scheduler.M3U8PeerTaskListenerInterface;
 import com.arialyy.aria.core.scheduler.SubTaskListenerInterface;
 import com.arialyy.aria.core.upload.UploadTaskListener;
@@ -117,7 +117,7 @@ public class ProxyHelper {
   }
 
   private Set<Integer> checkProxyTypeByInterface(Class clazz) {
-    if (!BaseListenerInterface.class.isAssignableFrom(clazz)) {
+    if (!DownloadTaskInternalListenerInterface.class.isAssignableFrom(clazz)) {
       return null;
     }
     Set<Integer> result = new HashSet<>();

--- a/Aria/src/main/java/com/arialyy/aria/core/download/DownloadGroupTaskListener.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/download/DownloadGroupTaskListener.java
@@ -1,0 +1,11 @@
+package com.arialyy.aria.core.download;
+
+import com.arialyy.aria.core.scheduler.NormalTaskListenerInterface;
+import com.arialyy.aria.core.task.DownloadGroupTask;
+
+/**
+ * @author ChenFei(chenfei0928 @ gmail.com)
+ * @date 2020-07-07 14:12
+ */
+public interface DownloadGroupTaskListener extends NormalTaskListenerInterface<DownloadGroupTask> {
+}

--- a/Aria/src/main/java/com/arialyy/aria/core/download/DownloadTaskListener.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/download/DownloadTaskListener.java
@@ -1,0 +1,11 @@
+package com.arialyy.aria.core.download;
+
+import com.arialyy.aria.core.scheduler.NormalTaskListenerInterface;
+import com.arialyy.aria.core.task.DownloadTask;
+
+/**
+ * @author ChenFei(chenfei0928 @ gmail.com)
+ * @date 2020-07-07 14:12
+ */
+public interface DownloadTaskListener extends NormalTaskListenerInterface<DownloadTask> {
+}

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/BaseListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/BaseListenerInterface.java
@@ -1,8 +1,0 @@
-package com.arialyy.aria.core.scheduler;
-
-/**
- * @author ChenFei(chenfei0928 @ gmail.com)
- * @date 2020-07-07 15:18
- */
-public interface BaseListenerInterface {
-}

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/BaseListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/BaseListenerInterface.java
@@ -1,0 +1,8 @@
+package com.arialyy.aria.core.scheduler;
+
+/**
+ * @author ChenFei(chenfei0928 @ gmail.com)
+ * @date 2020-07-07 15:18
+ */
+public interface BaseListenerInterface {
+}

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/DownloadTaskInternalListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/DownloadTaskInternalListenerInterface.java
@@ -1,0 +1,10 @@
+package com.arialyy.aria.core.scheduler;
+
+/**
+ * 直接实现监听器回调接口的基类，不对外部直接开放，仅作为内部监听器的父接口使用
+ *
+ * @author ChenFei(chenfei0928 @ gmail.com)
+ * @date 2020-07-07 15:18
+ */
+public interface DownloadTaskInternalListenerInterface {
+}

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/M3U8PeerTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/M3U8PeerTaskListenerInterface.java
@@ -19,7 +19,7 @@ package com.arialyy.aria.core.scheduler;
  * Created by Aria.Lao on 2019/6/26.
  * m3u8切片事件回调类
  */
-public interface M3U8PeerTaskListenerInterface extends BaseListenerInterface {
+public interface M3U8PeerTaskListenerInterface extends DownloadTaskInternalListenerInterface {
 
   public void onPeerStart(final String m3u8Url, final String peerPath, final int peerIndex);
 

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/M3U8PeerTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/M3U8PeerTaskListenerInterface.java
@@ -19,18 +19,11 @@ package com.arialyy.aria.core.scheduler;
  * Created by Aria.Lao on 2019/6/26.
  * m3u8切片事件回调类
  */
-public class M3U8PeerTaskListener implements M3U8PeerTaskListenerInterface, ISchedulerListener{
+public interface M3U8PeerTaskListenerInterface extends BaseListenerInterface {
 
-  @Override public void onPeerStart(final String m3u8Url, final String peerPath, final int peerIndex) {
-  }
+  public void onPeerStart(final String m3u8Url, final String peerPath, final int peerIndex);
 
-  @Override public void onPeerComplete(final String m3u8Url, final String peerPath, final int peerIndex) {
-  }
+  public void onPeerComplete(final String m3u8Url, final String peerPath, final int peerIndex);
 
-  @Override public void onPeerFail(final String m3u8Url, final String peerPath, final int peerIndex) {
-  }
-
-  @Override public void setListener(Object obj) {
-
-  }
+  public void onPeerFail(final String m3u8Url, final String peerPath, final int peerIndex);
 }

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/NormalTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/NormalTaskListenerInterface.java
@@ -24,93 +24,58 @@ import com.arialyy.aria.core.task.UploadTask;
  * Created by Aria.Lao on 2017/6/7.
  * 普通任务事件{@link DownloadTask}、{@link UploadTask}、{@link DownloadGroupTask}回调类
  */
-public class NormalTaskListener<TASK extends ITask> implements NormalTaskListenerInterface<TASK>, ISchedulerListener {
+public interface NormalTaskListenerInterface<TASK extends ITask> extends BaseListenerInterface {
 
   /**
    * 队列已经满了，继续创建任务，将会回调该方法
    */
-  @Override public void onWait(TASK task) {
-
-  }
+  public void onWait(TASK task);
 
   /**
    * 预处理，有时有些地址链接比较慢，这时可以先在这个地方出来一些界面上的UI，如按钮的状态。
    * 在这个回调中，任务是获取不到文件大小，下载速度等参数
    */
-  @Override public void onPre(TASK task) {
-
-  }
+  public void onPre(TASK task);
 
   /**
    * 任务预加载完成
    */
-  @Override public void onTaskPre(TASK task) {
-
-  }
+  public void onTaskPre(TASK task);
 
   /**
    * 任务恢复下载
    */
-  @Override public void onTaskResume(TASK task) {
-
-  }
+  public void onTaskResume(TASK task);
 
   /**
    * 任务开始
    */
-  @Override public void onTaskStart(TASK task) {
-
-  }
+  public void onTaskStart(TASK task);
 
   /**
    * 任务停止
    */
-  @Override public void onTaskStop(TASK task) {
-
-  }
+  public void onTaskStop(TASK task);
 
   /**
    * 任务取消
    */
-  @Override public void onTaskCancel(TASK task) {
-
-  }
-
-  /**
-   * 任务失败
-   *
-   * @deprecated {@link #onTaskFail(ITask, Exception)}
-   */
-  public void onTaskFail(TASK task) {
-
-  }
+  public void onTaskCancel(TASK task);
 
   /**
    * 任务失败
    */
-  @Override public void onTaskFail(TASK task, Exception e) {
-
-  }
+  public void onTaskFail(TASK task, Exception e);
 
   /**
    * 任务完成
    */
-  @Override public void onTaskComplete(TASK task) {
-
-  }
+  public void onTaskComplete(TASK task);
 
   /**
    * 任务执行中
    */
-  @Override public void onTaskRunning(TASK task) {
+  public void onTaskRunning(TASK task);
 
-  }
-
-  @Override public void onNoSupportBreakPoint(TASK task) {
-
-  }
-
-  @Override public void setListener(Object obj) {
-
-  }
+  public void onNoSupportBreakPoint(TASK task);
 }

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/NormalTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/NormalTaskListenerInterface.java
@@ -24,7 +24,7 @@ import com.arialyy.aria.core.task.UploadTask;
  * Created by Aria.Lao on 2017/6/7.
  * 普通任务事件{@link DownloadTask}、{@link UploadTask}、{@link DownloadGroupTask}回调类
  */
-public interface NormalTaskListenerInterface<TASK extends ITask> extends BaseListenerInterface {
+public interface NormalTaskListenerInterface<TASK extends ITask> extends DownloadTaskInternalListenerInterface {
 
   /**
    * 队列已经满了，继续创建任务，将会回调该方法

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListener.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListener.java
@@ -23,29 +23,29 @@ import com.arialyy.aria.core.task.ITask;
  * 子任务事件回调类
  */
 public class SubTaskListener<TASK extends ITask, SUB_ENTITY extends AbsNormalEntity>
-    implements ISchedulerListener {
+    implements SubTaskListenerInterface<TASK, SUB_ENTITY>, ISchedulerListener {
 
-  public void onNoSupportBreakPoint(TASK task) {
-
-  }
-
-  public void onSubTaskPre(TASK task, SUB_ENTITY subTask) {
+  @Override public void onNoSupportBreakPoint(TASK task) {
 
   }
 
-  public void onSubTaskStart(TASK task, SUB_ENTITY subTask) {
+  @Override public void onSubTaskPre(TASK task, SUB_ENTITY subTask) {
 
   }
 
-  public void onSubTaskStop(TASK task, SUB_ENTITY subTask) {
+  @Override public void onSubTaskStart(TASK task, SUB_ENTITY subTask) {
 
   }
 
-  public void onSubTaskCancel(TASK task, SUB_ENTITY subTask) {
+  @Override public void onSubTaskStop(TASK task, SUB_ENTITY subTask) {
 
   }
 
-  public void onSubTaskComplete(TASK task, SUB_ENTITY subTask) {
+  @Override public void onSubTaskCancel(TASK task, SUB_ENTITY subTask) {
+
+  }
+
+  @Override public void onSubTaskComplete(TASK task, SUB_ENTITY subTask) {
 
   }
 
@@ -54,11 +54,11 @@ public class SubTaskListener<TASK extends ITask, SUB_ENTITY extends AbsNormalEnt
 
   }
 
-  public void onSubTaskFail(TASK task, SUB_ENTITY subTask, Exception e) {
+  @Override public void onSubTaskFail(TASK task, SUB_ENTITY subTask, Exception e) {
 
   }
 
-  public void onSubTaskRunning(TASK task, SUB_ENTITY subTask) {
+  @Override public void onSubTaskRunning(TASK task, SUB_ENTITY subTask) {
 
   }
 

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListenerInterface.java
@@ -22,7 +22,7 @@ import com.arialyy.aria.core.task.ITask;
  * Created by Aria.Lao on 2019/6/26.
  * 子任务事件回调类
  */
-public interface SubTaskListenerInterface<TASK extends ITask, SUB_ENTITY extends AbsNormalEntity> extends BaseListenerInterface {
+public interface SubTaskListenerInterface<TASK extends ITask, SUB_ENTITY extends AbsNormalEntity> extends DownloadTaskInternalListenerInterface {
 
   public void onNoSupportBreakPoint(TASK task);
 

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListenerInterface.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/SubTaskListenerInterface.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 AriaLyy(https://github.com/AriaLyy/Aria)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arialyy.aria.core.scheduler;
+
+import com.arialyy.aria.core.common.AbsNormalEntity;
+import com.arialyy.aria.core.task.ITask;
+
+/**
+ * Created by Aria.Lao on 2019/6/26.
+ * 子任务事件回调类
+ */
+public interface SubTaskListenerInterface<TASK extends ITask, SUB_ENTITY extends AbsNormalEntity> extends BaseListenerInterface {
+
+  public void onNoSupportBreakPoint(TASK task);
+
+  public void onSubTaskPre(TASK task, SUB_ENTITY subTask);
+
+  public void onSubTaskStart(TASK task, SUB_ENTITY subTask);
+
+  public void onSubTaskStop(TASK task, SUB_ENTITY subTask);
+
+  public void onSubTaskCancel(TASK task, SUB_ENTITY subTask);
+
+  public void onSubTaskComplete(TASK task, SUB_ENTITY subTask);
+
+  public void onSubTaskFail(TASK task, SUB_ENTITY subTask, Exception e);
+
+  public void onSubTaskRunning(TASK task, SUB_ENTITY subTask);
+}

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
@@ -239,6 +239,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     boolean canSend = mAriaConfig.getAConfig().isUseBroadcast();
     if (canSend) {
       Intent intent = new Intent(ISchedulers.ARIA_TASK_INFO_ACTION);
+      intent.setPackage(mAriaConfig.getAPP().getPackageName());
       intent.putExtras(data);
       mAriaConfig.getAPP().sendBroadcast(intent);
     }
@@ -362,6 +363,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     boolean canSend = mAriaConfig.getAConfig().isUseBroadcast();
     if (canSend) {
       Intent intent = new Intent(ISchedulers.ARIA_TASK_INFO_ACTION);
+      intent.setPackage(mAriaConfig.getAPP().getPackageName());
       Bundle b = new Bundle();
       b.putInt(ISchedulers.TASK_TYPE, taskType);
       b.putInt(ISchedulers.TASK_STATE, ISchedulers.FAIL);
@@ -501,6 +503,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
    */
   private Intent createData(int taskState, int taskType, AbsEntity entity) {
     Intent intent = new Intent(ISchedulers.ARIA_TASK_INFO_ACTION);
+    intent.setPackage(mAriaConfig.getAPP().getPackageName());
     Bundle b = new Bundle();
     b.putInt(ISchedulers.TASK_TYPE, taskType);
     b.putInt(ISchedulers.TASK_STATE, taskState);

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
@@ -54,7 +54,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
   private static volatile TaskSchedulers INSTANCE;
   private static FailureTaskHandler mFailureTaskHandler;
 
-  private Map<String, Map<TaskEnum, ISchedulerListener>> mObservers = new ConcurrentHashMap<>();
+  private Map<String, Map<TaskEnum, Object>> mObservers = new ConcurrentHashMap<>();
   private AriaConfig mAriaConfig;
 
   private TaskSchedulers() {
@@ -99,15 +99,19 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
    */
   public void register(Object obj, TaskEnum taskEnum) {
     String targetName = obj.getClass().getName();
-    Map<TaskEnum, ISchedulerListener> listeners = mObservers.get(getKey(obj));
+    Map<TaskEnum, Object> listeners = mObservers.get(getKey(obj));
 
     if (listeners == null) {
       listeners = new ConcurrentHashMap<>();
       mObservers.put(getKey(obj), listeners);
     }
-    String proxyClassName = targetName + taskEnum.proxySuffix;
 
     if (!hasProxyListener(listeners, taskEnum)) {
+      if (obj instanceof BaseListenerInterface){
+        listeners.put(taskEnum, (ISchedulerListener) obj);
+        return;
+      }
+      String proxyClassName = targetName + taskEnum.proxySuffix;
       ISchedulerListener listener = createListener(proxyClassName);
       if (listener != null) {
         listener.setListener(obj);
@@ -124,7 +128,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
    * @param taskEnum 代理类类型
    * @return true，已注册代理类，false，没有注册代理类
    */
-  private boolean hasProxyListener(Map<TaskEnum, ISchedulerListener> listeners, TaskEnum taskEnum) {
+  private boolean hasProxyListener(Map<TaskEnum, Object> listeners, TaskEnum taskEnum) {
     return !listeners.isEmpty() && listeners.get(taskEnum) != null;
   }
 
@@ -137,9 +141,9 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     if (!mObservers.containsKey(getKey(obj))) {
       return;
     }
-    for (Iterator<Map.Entry<String, Map<TaskEnum, ISchedulerListener>>> iter =
+    for (Iterator<Map.Entry<String, Map<TaskEnum, Object>>> iter =
         mObservers.entrySet().iterator(); iter.hasNext(); ) {
-      Map.Entry<String, Map<TaskEnum, ISchedulerListener>> entry = iter.next();
+      Map.Entry<String, Map<TaskEnum, Object>> entry = iter.next();
 
       if (entry.getKey().equals(getKey(obj))) {
         iter.remove();
@@ -202,12 +206,12 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     if (mObservers.size() > 0) {
       Set<String> keys = mObservers.keySet();
       for (String key : keys) {
-        Map<TaskEnum, ISchedulerListener> listeners = mObservers.get(key);
+        Map<TaskEnum, Object> listeners = mObservers.get(key);
         if (listeners == null || listeners.isEmpty()) {
           continue;
         }
-        M3U8PeerTaskListener listener =
-            (M3U8PeerTaskListener) listeners.get(TaskEnum.M3U8_PEER);
+        M3U8PeerTaskListenerInterface listener =
+            (M3U8PeerTaskListenerInterface) listeners.get(TaskEnum.M3U8_PEER);
         if (listener == null) {
           continue;
         }
@@ -250,12 +254,12 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     if (mObservers.size() > 0) {
       Set<String> keys = mObservers.keySet();
       for (String key : keys) {
-        Map<TaskEnum, ISchedulerListener> listeners = mObservers.get(key);
+        Map<TaskEnum, Object> listeners = mObservers.get(key);
         if (listeners == null || listeners.isEmpty()) {
           continue;
         }
-        SubTaskListener<TASK, AbsNormalEntity> listener =
-            (SubTaskListener<TASK, AbsNormalEntity>) listeners.get(TaskEnum.DOWNLOAD_GROUP_SUB);
+        SubTaskListenerInterface<TASK, AbsNormalEntity> listener =
+            (SubTaskListenerInterface<TASK, AbsNormalEntity>) listeners.get(TaskEnum.DOWNLOAD_GROUP_SUB);
         if (listener == null) {
           continue;
         }
@@ -368,18 +372,18 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     if (mObservers.size() > 0) {
       Set<String> keys = mObservers.keySet();
       for (String key : keys) {
-        Map<TaskEnum, ISchedulerListener> listeners = mObservers.get(key);
+        Map<TaskEnum, Object> listeners = mObservers.get(key);
         if (listeners == null || listeners.isEmpty()) {
           continue;
         }
-        NormalTaskListener<TASK> listener = null;
+        NormalTaskListenerInterface<TASK> listener = null;
         if (mObservers.get(key) != null) {
           if (taskType == ITask.DOWNLOAD) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.DOWNLOAD);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.DOWNLOAD);
           } else if (taskType == ITask.DOWNLOAD_GROUP) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.DOWNLOAD_GROUP);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.DOWNLOAD_GROUP);
           } else if (taskType == ITask.DOWNLOAD_GROUP) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.UPLOAD);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.UPLOAD);
           }
         }
         if (listener != null) {
@@ -399,7 +403,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     if (mObservers.size() > 0) {
       Set<String> keys = mObservers.keySet();
       for (String key : keys) {
-        Map<TaskEnum, ISchedulerListener> listeners = mObservers.get(key);
+        Map<TaskEnum, Object> listeners = mObservers.get(key);
         if (listeners == null || listeners.isEmpty()) {
           continue;
         }
@@ -420,7 +424,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     }
   }
 
-  private void normalTaskCallback(int state, TASK task, NormalTaskListener<TASK> listener) {
+  private void normalTaskCallback(int state, TASK task, NormalTaskListenerInterface<TASK> listener) {
     if (listener != null) {
       if (task == null && state != ISchedulers.CHECK_FAIL) {
         ALog.e(TAG, "TASK 为null，回调失败");

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
@@ -18,7 +18,6 @@ package com.arialyy.aria.core.scheduler;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Message;
-import android.util.Log;
 import com.arialyy.annotations.TaskEnum;
 import com.arialyy.aria.core.AriaConfig;
 import com.arialyy.aria.core.common.AbsEntity;
@@ -107,8 +106,8 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     }
 
     if (!hasProxyListener(listeners, taskEnum)) {
-      if (obj instanceof BaseListenerInterface){
-        listeners.put(taskEnum, (ISchedulerListener) obj);
+      if (obj instanceof BaseListenerInterface) {
+        listeners.put(taskEnum, obj);
         return;
       }
       String proxyClassName = targetName + taskEnum.proxySuffix;
@@ -409,14 +408,14 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
         if (listeners == null || listeners.isEmpty()) {
           continue;
         }
-        NormalTaskListener<TASK> listener = null;
+        NormalTaskListenerInterface<TASK> listener = null;
         if (mObservers.get(key) != null) {
           if (task instanceof DownloadTask) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.DOWNLOAD);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.DOWNLOAD);
           } else if (task instanceof DownloadGroupTask) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.DOWNLOAD_GROUP);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.DOWNLOAD_GROUP);
           } else if (task instanceof UploadTask) {
-            listener = (NormalTaskListener<TASK>) listeners.get(TaskEnum.UPLOAD);
+            listener = (NormalTaskListenerInterface<TASK>) listeners.get(TaskEnum.UPLOAD);
           }
         }
         if (listener != null) {

--- a/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/scheduler/TaskSchedulers.java
@@ -106,7 +106,7 @@ public class TaskSchedulers<TASK extends ITask> implements ISchedulers {
     }
 
     if (!hasProxyListener(listeners, taskEnum)) {
-      if (obj instanceof BaseListenerInterface) {
+      if (obj instanceof DownloadTaskInternalListenerInterface) {
         listeners.put(taskEnum, obj);
         return;
       }

--- a/Aria/src/main/java/com/arialyy/aria/core/upload/UploadTaskListener.java
+++ b/Aria/src/main/java/com/arialyy/aria/core/upload/UploadTaskListener.java
@@ -1,0 +1,13 @@
+package com.arialyy.aria.core.upload;
+
+import com.arialyy.aria.core.scheduler.NormalTaskListenerInterface;
+import com.arialyy.aria.core.task.UploadTask;
+
+/**
+ * 上传任务接口
+ *
+ * @author ChenFei(chenfei0928 @ gmail.com)
+ * @date 2020-07-07 13:23
+ */
+public interface UploadTaskListener extends NormalTaskListenerInterface<UploadTask> {
+}


### PR DESCRIPTION
抽离下载任务监听器接口，以允许直接通过实现监听器而非apt注释处理方式来接收任务下载事件更新
对通过广播方式更新下载进度事件添加了广播目标包约束